### PR TITLE
Syntax changes

### DIFF
--- a/src/core/utils/utils.js
+++ b/src/core/utils/utils.js
@@ -1,16 +1,19 @@
-'use strict'
+'use strict';
+
 module.exports.ENV = {
     port:3001
 };
 
-module.exports.getSetup = function getSetup(name) {
+module.exports.getSetup = function (name) {
     let root = '../config';
     let path = '/DC';
+    
     switch (name.toUpperCase()) {
         case 'DC':
             path = '/DC';
             break;
     }
+    
     let setup = require(root + path + '/setup.js').Setup;
     let Powers = require(root + path + '/powers.js');
     setup.powers = new Powers();


### PR DESCRIPTION
It _always_ needs a ; after the 'use strict' sentence.

When directly declaring an export, a named function is not required because the name will be overwritten anyway, so instead of:

```js
module.exports.myFunc = function myFunc(blah) {}
```

is enough and much more readable:

```js
module.exports.myFunc = function (name) {}
```